### PR TITLE
Make the support module build on Windows

### DIFF
--- a/CAENHVAsynApp/src/Makefile
+++ b/CAENHVAsynApp/src/Makefile
@@ -26,10 +26,16 @@ LIB_LIBS += asyn
 #=====================================================
 # Path to "NON EPICS" External PACKAGES: USER INCLUDES
 #======================================================
+
 USR_INCLUDES = $(addprefix -I,$(CAENHVWRAPPER_INCLUDE))
 caenhvwrapper_DIR = $(CAENHVWRAPPER_LIB)
 USR_LIBS_Linux += caenhvwrapper
-#======================================================
+
+LIB_LIBS_WIN32 += caenhvwrapper
+BIN_INSTALLS_WIN32 += $(wildcard $(CAENHVWRAPPER_DLL)/*.dll)
+LIB_INSTALLS_WIN32 += $(wildcard $(CAENHVWRAPPER_LIB)/*.lib)
+LIB_SYS_LIBS_WIN32 += ws2_32
+LIB_LIBS_WIN32 += $(EPICS_BASE_IOC_LIBS)
 
 #===========================
 

--- a/CAENHVAsynApp/src/board.cpp
+++ b/CAENHVAsynApp/src/board.cpp
@@ -130,8 +130,11 @@ void IBoard::GetBoardParams()
             std::cerr << "Error found when creating a Board Parameter object for pamater '" << p[i] << "'. Unsupported type = " << type << std::endl;
     }
 
+    // Memory allocated across CRTs can cause issues on Windows
+#ifndef _WIN32
     // Deallocate memory (Use RAII in the future for this)
     free(ParNameList);
+#endif
 }
 
 void IBoard::GetBoardChannels()

--- a/CAENHVAsynApp/src/board.h
+++ b/CAENHVAsynApp/src/board.h
@@ -34,7 +34,13 @@
 #include <vector>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"

--- a/CAENHVAsynApp/src/board_parameter.h
+++ b/CAENHVAsynApp/src/board_parameter.h
@@ -35,7 +35,13 @@
 #include <algorithm>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"

--- a/CAENHVAsynApp/src/channel.cpp
+++ b/CAENHVAsynApp/src/channel.cpp
@@ -112,6 +112,9 @@ void IChannel::GetChannelParams()
             std::cerr << "Error found when creating a Board Parameter object for pamater '" << p[i] << "'. Unsupported type = " << type << std::endl;
     }
 
+    // Memory allocated across CRTs can cause issues on Windows
+#ifndef _WIN32
     // Deallocate memory (Use RAII in the future for this)
     free(ParNameList);
+#endif
 }

--- a/CAENHVAsynApp/src/channel.h
+++ b/CAENHVAsynApp/src/channel.h
@@ -34,7 +34,13 @@
 #include <vector>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"

--- a/CAENHVAsynApp/src/channel_parameter.h
+++ b/CAENHVAsynApp/src/channel_parameter.h
@@ -34,7 +34,13 @@
 #include <memory>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"

--- a/CAENHVAsynApp/src/common.h
+++ b/CAENHVAsynApp/src/common.h
@@ -35,7 +35,13 @@
 #include <algorithm>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 #include "CAENHVWrapper.h"
 

--- a/CAENHVAsynApp/src/crate.cpp
+++ b/CAENHVAsynApp/src/crate.cpp
@@ -81,7 +81,10 @@ void ICrate::GetPropList()
         }
     }
 
+    // Memory allocated across CRTs can cause issues on Windows
+    #ifndef _WIN32
     free(PropNameList);
+    #endif
 }
 
 void ICrate::GetCrateMap()
@@ -130,6 +133,8 @@ void ICrate::GetCrateMap()
         }
     }
 
+    // Memory allocated across CRTs can cause issues on Windows
+    #ifndef _WIN32
     // Deallocate memory (Use RAII in the future for this)
     free(NrOfChList);
     free(ModelList);
@@ -137,6 +142,7 @@ void ICrate::GetCrateMap()
     free(SerNumList);
     free(FmwRelMinList);
     free(FmwRelMaxList);
+    #endif
 }
 
 ICrate::ICrate(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password)

--- a/CAENHVAsynApp/src/crate.h
+++ b/CAENHVAsynApp/src/crate.h
@@ -34,7 +34,13 @@
 #include <vector>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
@@ -40,7 +40,7 @@ void CAENHVAsyn::createParamFloat(T p, std::map<int, T>& list)
     int index;
     createParam(paramName.c_str(), asynParamFloat64, &index);
 
-    list.insert( std::make_pair<int, T>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -87,7 +87,7 @@ void CAENHVAsyn::createParamFloat(SystemPropertyFloat p, std::map<int, SystemPro
     int index;
     createParam(paramName.c_str(), asynParamFloat64, &index);
 
-    list.insert( std::make_pair<int, SystemPropertyFloat>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -115,7 +115,7 @@ void CAENHVAsyn::createParamFloat(SystemPropertyFloat p, std::map<int, SystemPro
             dbParamsLocal << ",DRVL=";
             dbParamsLocal << ",DRVH=";
             dbParamsLocal << ",R="    << recordName << ":St";
-            dbLoadRecords("db/ao.template", dbParamsLocal.str().c_str());
+            dbLoadRecords("db/ao.template", dbParamsLocal.str().c_str());                                                               
         }
 
     }
@@ -134,7 +134,7 @@ void CAENHVAsyn::createParamBinary(T p, std::map<int, T>& list)
     int index;
     createParam(paramName.c_str(), asynParamUInt32Digital, &index);
 
-    list.insert( std::make_pair<int, T>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -175,7 +175,7 @@ void CAENHVAsyn::createParamMBinary(T p, std::map<int, T>& list, const statusRec
     int index;
     createParam(paramName.c_str(), asynParamUInt32Digital, &index);
 
-    list.insert( std::make_pair<int, T>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -233,7 +233,7 @@ void CAENHVAsyn::createParamInteger(T p, std::map<int, T>& list)
     int index;
     createParam(paramName.c_str(), asynParamInt32, &index);
 
-    list.insert( std::make_pair<int, T>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -272,7 +272,7 @@ void CAENHVAsyn::createParamString(T p, std::map<int, T>& list)
     int index;
     createParam(paramName.c_str(), asynParamOctet, &index);
 
-    list.insert( std::make_pair<int, T>(index, p) );
+    list.insert( std::make_pair(index, p) );
 
     if (!epicsPrefix.empty())
     {
@@ -355,9 +355,9 @@ CAENHVAsyn::CAENHVAsyn(const std::string& portName, int systemType, const std::s
     std::ofstream infoFile;
 
     std::cout << "Dumping crate information on '" << infoFileName << "'... ";
-    infoFile.open(infoFileName);
-    crate->printInfo(infoFile);
-    infoFile.close();
+    //infoFile.open(infoFileName);
+    //crate->printInfo(infoFile);
+    //infoFile.close();
     std::cout  << "Done" << std::endl;
 
     if (epicsPrefix.empty())

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
@@ -24,7 +24,12 @@
 // Default value for the EPICS record prefix is an empty string,
 // which means that the autogeration is disabled.
 std::string CAENHVAsyn::epicsPrefix;
+#ifdef _WIN32
+std::string CAENHVAsyn::crateInfoFilePath = "";
+#else
 std::string CAENHVAsyn::crateInfoFilePath = "/tmp/";
+#endif
+
 
 template <typename T>
 void CAENHVAsyn::createParamFloat(T p, std::map<int, T>& list)
@@ -355,9 +360,9 @@ CAENHVAsyn::CAENHVAsyn(const std::string& portName, int systemType, const std::s
     std::ofstream infoFile;
 
     std::cout << "Dumping crate information on '" << infoFileName << "'... ";
-    //infoFile.open(infoFileName);
-    //crate->printInfo(infoFile);
-    //infoFile.close();
+    infoFile.open(infoFileName);
+    crate->printInfo(infoFile);
+    infoFile.close();
     std::cout  << "Done" << std::endl;
 
     if (epicsPrefix.empty())

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.h
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.h
@@ -36,7 +36,14 @@
 #include <fstream>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <epicsTypes.h>
 #include <epicsTime.h>
 #include <epicsThread.h>

--- a/CAENHVAsynApp/src/system_property.cpp
+++ b/CAENHVAsynApp/src/system_property.cpp
@@ -93,13 +93,15 @@ void ISystemPropertyString::setVal(const std::string& v) const
     if (mode == SYSPROP_MODE_RDONLY)
         return;
 
-    char temp[v.size() + 1];
+    char* temp = new char[v.size() + 1];
     strcpy(temp, v.c_str());
 
     CAENHVRESULT r = CAENHV_SetSysProp(handle, prop.c_str(), temp);
 
     if ( r != CAENHV_OK && r != CAENHV_GETPROPNOTIMPL && r != CAENHV_NOTGETPROP )
         throw std::runtime_error("CAENHV_SetSysProp failed: " + std::string(CAENHV_GetError(handle)));
+
+    delete[] temp;
 }
 
 // Float class

--- a/CAENHVAsynApp/src/system_property.h
+++ b/CAENHVAsynApp/src/system_property.h
@@ -34,7 +34,13 @@
 #include <memory>
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <arpa/inet.h>
+#endif
+
 #include <iostream>
 
 #include "CAENHVWrapper.h"


### PR DESCRIPTION
I found this support module when attempting to update our code to read board temperatures. It seemed easier to convert this to build on Windows than to add board temperatures to our codebase (yours is also better written that the one we have). To get it to run on Windows I have:
* Replaced `arpa/inet.h` with `winsock2.h`
* Added extra dependencies in the makefile
* Not freed memory where it's being allocated in the vendor code. This is due to the vendor code being run in a different CRT than this code, which causes memory issues. We will just have to take the small memory leak hit on Windows. 
* Allow the compiler to assume the type for `make_pair` - not too sure why this wasn't working for my compiler versions
* Write the info file directly to the top

I believe I've added these changes in such a way that they won't affect it running on linux but I don't have a linux machine to hand to test it on. Happy to accept any suggestions you might have.

As we start to use this driver more we may add additional features, we can let you know when we plan to do so.