### PR TITLE
Expose Channel name as a PV

### DIFF
--- a/CAENHVAsynApp/src/channel.cpp
+++ b/CAENHVAsynApp/src/channel.cpp
@@ -40,6 +40,10 @@ void IChannel::printInfo(std::ostream& stream) const
     stream << "      Slot = " << slot \
            << ", Channel = " << channel \
            << std::endl;
+    
+    stream << "        Number of String parameters: " << channelParameterStrings.size() << std::endl;
+    for (std::vector<ChannelParameterString>::const_iterator it = channelParameterStrings.begin(); it != channelParameterStrings.end(); ++it)
+        (*it)->printInfo(stream);
 
     stream << "        Number of Numeric parameters: " << channelParameterNumerics.size() << std::endl;
     for (std::vector<ChannelParameterNumeric>::const_iterator it = channelParameterNumerics.begin(); it != channelParameterNumerics.end(); ++it)
@@ -75,6 +79,9 @@ void IChannel::GetChannelParams()
 
     if ( r != CAENHV_OK )
         return;
+
+    // Get the channel name
+    channelParameterStrings.push_back( IChannelName::create(handle, slot, channel, "NAME", PARAM_MODE_RDWR) );
 
     // Check if we the number of parameter is > 0
     if (ParNumber <= 0)

--- a/CAENHVAsynApp/src/channel.h
+++ b/CAENHVAsynApp/src/channel.h
@@ -57,6 +57,7 @@ public:
 
     void printInfo(std::ostream& stream) const;
 
+    std::vector<ChannelParameterString>   getChannelParameterStrings()    { return channelParameterStrings; };
     std::vector<ChannelParameterNumeric>  getChannelParameterNumerics()   { return channelParameterNumerics;   };
     std::vector<ChannelParameterOnOff>    getChannelParameterOnOffs()     { return channelParameterOnOffs;     };
     std::vector<ChannelParameterChStatus> getChannelParameterChStatuses() { return channelParameterChStatuses; };
@@ -70,6 +71,7 @@ private:
     std::size_t                 slot;
     std::size_t                 channel;
 
+    std::vector<ChannelParameterString>   channelParameterStrings;
     std::vector<ChannelParameterNumeric>  channelParameterNumerics;
     std::vector<ChannelParameterOnOff>    channelParameterOnOffs;
     std::vector<ChannelParameterChStatus> channelParameterChStatuses;

--- a/CAENHVAsynApp/src/channel_parameter.cpp
+++ b/CAENHVAsynApp/src/channel_parameter.cpp
@@ -156,12 +156,12 @@ IChannelParameterOnOff::IChannelParameterOnOff(int h, std::size_t s, std::size_t
    char temp[30];
 
    if ( CAENHV_GetChParamProp(handle, slot, channel, param.c_str(), "Onstate", temp ) != CAENHV_OK )
-       throw std::runtime_error("CAENHV_GetBdParamProp failed: " + std::string(CAENHV_GetError(handle)));
+       throw std::runtime_error("CAENHV_GetChParamProp failed: " + std::string(CAENHV_GetError(handle)));
 
    onState = temp;
 
    if ( CAENHV_GetChParamProp(handle, slot, channel, param.c_str(), "Offstate", temp ) != CAENHV_OK )
-       throw std::runtime_error("CAENHV_GetBdParamProp failed: " + std::string(CAENHV_GetError(handle)));
+       throw std::runtime_error("CAENHV_GetChParamProp failed: " + std::string(CAENHV_GetError(handle)));
 
     offState = temp;
 
@@ -221,4 +221,46 @@ void IChannelParameterBinary::printInfo(std::ostream& stream) const
            << ", epicsParamName = "  << epicsParamName \
            << ", epicsRecordName = " << epicsRecordName \
            << std::endl;
+}
+
+// Class for String parameters
+IChannelParameterString::IChannelParameterString(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m)
+    :
+    ChannelParameterBase<std::string>(h, s, c, p, m)
+{
+}
+
+ChannelParameterString IChannelParameterString::create(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m)
+{
+    return std::make_shared<IChannelParameterString>(h, s, c, p, m);
+}
+
+// Class for Channel Name
+IChannelName::IChannelName(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m)
+    :
+    IChannelParameterString(h, s, c, p, m)
+{
+}
+
+ChannelName IChannelName::create(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m)
+{
+    return std::make_shared<IChannelName>(h, s, c, p, m);
+}
+
+std::string IChannelName::getVal() const
+{
+    char name_char[MAX_CH_NAME];
+
+    uint16_t tempChan = channel;
+    if (CAENHV_GetChName(handle, slot, 1, &tempChan, &name_char) != CAENHV_OK)
+        throw std::runtime_error("CAENHV_GetChName failed: " + std::string(CAENHV_GetError(handle)));
+
+    return std::string(name_char);
+}
+
+void IChannelName::setVal(std::string name) const
+{
+    uint16_t tempChan = channel;
+    if (CAENHV_SetChName(handle, slot, 1, &tempChan, name.c_str()) != CAENHV_OK)
+        throw std::runtime_error("CAENHV_SetChName failed: " + std::string(CAENHV_GetError(handle)));
 }

--- a/CAENHVAsynApp/src/channel_parameter.h
+++ b/CAENHVAsynApp/src/channel_parameter.h
@@ -46,12 +46,16 @@ class IChannelParameterNumeric;
 class IChannelParameterOnOff;
 class IChannelParameterChStatus;
 class IChannelParameterBinary;
+class IChannelParameterString;
+class IChannelName;
 
 // Shared pointer types
 typedef std::shared_ptr< IChannelParameterNumeric  > ChannelParameterNumeric;
 typedef std::shared_ptr< IChannelParameterOnOff    > ChannelParameterOnOff;
 typedef std::shared_ptr< IChannelParameterChStatus > ChannelParameterChStatus;
 typedef std::shared_ptr< IChannelParameterBinary   > ChannelParameterBinary;
+typedef std::shared_ptr< IChannelParameterString   > ChannelParameterString;
+typedef std::shared_ptr< IChannelName              > ChannelName;
 
 template<typename T>
 class ChannelParameterBase
@@ -149,6 +153,31 @@ public:
     static ChannelParameterBinary create(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m);
 
     virtual void printInfo(std::ostream& stream) const;
+};
+
+// Class for String Parameters
+class IChannelParameterString : public ChannelParameterBase<std::string>
+{
+public:
+    IChannelParameterString(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m);
+    ~IChannelParameterString() {};
+
+    // Factory method
+    static ChannelParameterString create(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m);
+};
+
+// Class for Channel name (not really a parameter as CAEN defines it)
+class IChannelName : public IChannelParameterString
+{
+public:
+    IChannelName(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m);
+    ~IChannelName() {};
+
+    // Factory method
+    static ChannelName create(int h, std::size_t s, std::size_t c, const std::string&  p, uint32_t m);
+
+    virtual std::string    getVal()        const;
+    virtual void setVal(std::string value) const;
 };
 
 #endif

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.h
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.h
@@ -164,6 +164,7 @@ class CAENHVAsyn : public asynPortDriver
        std::map<int, BoardParameterBdStatus> boardParameterBdStatusList;
 
        // Channel parameter lists
+       std::map<int, ChannelParameterString>   channelParameterStringList;
        std::map<int, ChannelParameterNumeric>  channelParameterNumericList;
        std::map<int, ChannelParameterOnOff>    channelParameterOnOffList;
        std::map<int, ChannelParameterChStatus> channelParameterChStatusList;


### PR DESCRIPTION
Creates a `NAME` PV for each channel that allows you to get/set the channel name.

Although channel name isn't really a parameter in the CAEN's definition it seemed to make sense to reuse the channel parameter mechanism for it. Let me know if you have a better idea on how to integrate it.