### PR TITLE
Add a read only option to only expose reading parameters

### DIFF
--- a/CAENHVAsynApp/src/board.h
+++ b/CAENHVAsynApp/src/board.h
@@ -49,11 +49,11 @@ typedef std::shared_ptr<IBoard> Board;
 class IBoard
 {
 public:
-    IBoard(int h, std::size_t s, std::string m, std::string d, std::size_t n, std::string sn, std::string fw);
+    IBoard(int h, std::size_t s, std::string m, std::string d, std::size_t n, std::string sn, std::string fw, bool readOnly);
     ~IBoard();
 
     // Factory method
-    static Board create(int h, std::size_t s, std::string m, std::string d, std::size_t n, std::string sn, std::string fw);
+    static Board create(int h, std::size_t s, std::string m, std::string d, std::size_t n, std::string sn, std::string fw, bool readOnly);
 
     void printInfo(std::ostream& stream) const;
     void printBoardInfo(std::ostream& stream) const;
@@ -76,6 +76,7 @@ private:
     std::size_t                 numChannels;
     std::string                 serialNumber;
     std::string                 firmwareRelease;
+    bool                        readOnly;
 
     std::vector<BoardParameterNumeric>  boardParameterNumerics;
     std::vector<BoardParameterOnOff>    boardParameterOnOffs;

--- a/CAENHVAsynApp/src/channel.cpp
+++ b/CAENHVAsynApp/src/channel.cpp
@@ -21,18 +21,19 @@
 
 #include "channel.h"
 
-IChannel::IChannel(int h, std::size_t s, std::size_t c)
+IChannel::IChannel(int h, std::size_t s, std::size_t c, bool readOnly)
 :
     handle(h),
     slot(s),
-    channel(c)
+    channel(c),
+    readOnly(readOnly)
 {
     GetChannelParams();
 }
 
-Channel IChannel::create(int h, std::size_t s, std::size_t c)
+Channel IChannel::create(int h, std::size_t s, std::size_t c, bool readOnly)
 {
-    return std::make_shared<IChannel>(h, s, c);
+    return std::make_shared<IChannel>(h, s, c, readOnly);
 }
 
 void IChannel::printInfo(std::ostream& stream) const
@@ -98,6 +99,15 @@ void IChannel::GetChannelParams()
 
         if (CAENHV_GetChParamProp(handle, slot, channel, p[i], "Mode", &mode) != CAENHV_OK )
             throw std::runtime_error("CAENHV_GetChParamProp failed: " + std::string(CAENHV_GetError(handle)));
+
+        if (readOnly) {
+            if (mode == PARAM_MODE_RDWR) {
+                mode = PARAM_MODE_RDONLY;
+            }
+            else if (mode == PARAM_MODE_WRONLY) {
+                break;
+            }
+        }
 
         if (type == PARAM_TYPE_NUMERIC)
             channelParameterNumerics.push_back( IChannelParameterNumeric::create(handle, slot, channel, p[i], mode) );

--- a/CAENHVAsynApp/src/channel.h
+++ b/CAENHVAsynApp/src/channel.h
@@ -49,11 +49,11 @@ typedef std::shared_ptr<IChannel> Channel;
 class IChannel
 {
 public:
-    IChannel(int h, std::size_t s, std::size_t c);
+    IChannel(int h, std::size_t s, std::size_t c, bool readOnly);
     ~IChannel() {};
 
     // Factory method
-    static Channel create(int h, std::size_t s, std::size_t c);
+    static Channel create(int h, std::size_t s, std::size_t c, bool readOnly);
 
     void printInfo(std::ostream& stream) const;
 
@@ -69,6 +69,7 @@ private:
     int                         handle;
     std::size_t                 slot;
     std::size_t                 channel;
+    bool                        readOnly;
 
     std::vector<ChannelParameterNumeric>  channelParameterNumerics;
     std::vector<ChannelParameterOnOff>    channelParameterOnOffs;

--- a/CAENHVAsynApp/src/crate.cpp
+++ b/CAENHVAsynApp/src/crate.cpp
@@ -47,6 +47,13 @@ void ICrate::GetPropList()
         unsigned PropType;
         if ( CAENHV_GetSysPropInfo(handle, p, &PropMode, &PropType) == CAENHV_OK )
         {
+            if (readOnly) {
+                if (PropMode == SYSPROP_MODE_RDWR) {
+                    PropMode = SYSPROP_MODE_RDONLY;
+                } else if (PropMode == SYSPROP_MODE_WRONLY) {
+                    break;
+                }
+            }
             switch( PropType )
             {
                 case SYSPROP_TYPE_STR:
@@ -126,7 +133,7 @@ void ICrate::GetCrateMap()
             fw << unsigned(FmwRelMaxList[i]) << "." << unsigned(FmwRelMinList[i]);
 
             // Create a new Slot object and add it to the vector
-            boards.push_back( IBoard::create(handle, i, m, d, NrOfChList[i], sn.str(), fw.str()) );
+            boards.push_back( IBoard::create(handle, i, m, d, NrOfChList[i], sn.str(), fw.str(), readOnly) );
         }
     }
 
@@ -139,18 +146,19 @@ void ICrate::GetCrateMap()
     free(FmwRelMaxList);
 }
 
-ICrate::ICrate(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password)
+ICrate::ICrate(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password, const bool readOnly)
 :
-  handle(-1)
+  handle(-1),
+  readOnly(readOnly)
 {
     handle = InitSystem(systemType, ipAddr, userName, password);
     GetPropList();
     GetCrateMap();
 }
 
-Crate ICrate::create(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password)
+Crate ICrate::create(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password, const bool readOnly)
 {
-    return std::make_shared<ICrate>(systemType, ipAddr, userName, password);
+    return std::make_shared<ICrate>(systemType, ipAddr, userName, password, readOnly);
 }
 
 ICrate::~ICrate()

--- a/CAENHVAsynApp/src/crate.h
+++ b/CAENHVAsynApp/src/crate.h
@@ -53,11 +53,11 @@ typedef std::shared_ptr<ICrate> Crate;
 class ICrate
 {
 public:
-    ICrate(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password);
+    ICrate(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password, const bool readOnly);
     ~ICrate();
 
     // Factory method
-    static Crate create(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password);
+    static Crate create(int systemType, const std::string& ipAddr, const std::string& userName, const std::string& password, const bool readOnly);
 
     void printInfo(std::ostream& stream) const;
     void printCrateMap(std::ostream& stream) const;
@@ -78,6 +78,7 @@ private:
     void printProperties(std::ostream& stream, const std::string& type, const T& pv) const;
 
     int handle;
+    bool readOnly;
 
     // Number of slot in the crate
     std::size_t numSlots;

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.cpp
@@ -24,6 +24,9 @@
 // Default value for the EPICS record prefix is an empty string,
 // which means that the autogeration is disabled.
 std::string CAENHVAsyn::epicsPrefix;
+// If specified then only read calls are performed, defaults to false.
+bool CAENHVAsyn::readOnly = false;
+
 std::string CAENHVAsyn::crateInfoFilePath = "/tmp/";
 
 template <typename T>
@@ -338,7 +341,7 @@ CAENHVAsyn::CAENHVAsyn(const std::string& portName, int systemType, const std::s
         throw std::runtime_error("Unsupported system type. Only supported types are SYx527 (0-3)");
 
     // Create a Crate object
-    crate = ICrate::create(systemType, ipAddr, userName, password);
+    crate = ICrate::create(systemType, ipAddr, userName, password, readOnly);
 
     // Print the crate map to the IOC shell
     std::cout << std::endl;
@@ -1051,11 +1054,35 @@ static void epicsPrefixCallFunc(const iocshArgBuf *args)
 }
 // - CAENHVAsynSetEpicsPrefix //
 
+// + CAENHVAsynReadOnly //
+extern "C" int CAENHVAsynReadOnly(const bool readOnly)
+{
+    CAENHVAsyn::readOnly = readOnly;
+
+    return 0;
+}
+
+static const iocshArg readOnlyArg0 = { "ReadOnly", iocshArgInt };
+
+static const iocshArg * const readOnlyArgs[] =
+{
+    &readOnlyArg0
+};
+
+static const iocshFuncDef readOnlyFuncDef = { "CAENHVAsynReadOnly", 1, epicsPrefixArgs };
+
+static void readOnlyCallFunc(const iocshArgBuf *args)
+{
+    CAENHVAsynReadOnly(args[0].ival);
+}
+// - CAENHVAsynReadOnly //
+
 // iocshRegister
 void drvCAENHVAsynRegister(void)
 {
     iocshRegister( &configFuncDef,      configCallFunc      );
     iocshRegister( &epicsPrefixFuncDef, epicsPrefixCallFunc );
+    iocshRegister( &readOnlyFuncDef,    readOnlyCallFunc);
 }
 
 extern "C"

--- a/CAENHVAsynApp/src/drvCAENHVAsyn.h
+++ b/CAENHVAsynApp/src/drvCAENHVAsyn.h
@@ -130,6 +130,8 @@ class CAENHVAsyn : public asynPortDriver
         static std::string epicsPrefix;
         // Crate information output file location
         static std::string crateInfoFilePath;
+        // Whether to only read from the device
+        static bool readOnly;
 
     private:
 

--- a/README.configureDriver.md
+++ b/README.configureDriver.md
@@ -32,9 +32,11 @@ CAENHVAsynConfig(PORT_NAME, SYSTEM_TYPE, IP_ADDR, USER_NAME, PASSWORD)
 Some parameters used by the driver have default values that can be changed calling functions in your **st.cmd**. The following is a list these paramaters,
 their default values, and the function used to change them.
 
-| Parameter                                          | Default value     | Function to set a new value
-|----------------------------------------------------|-------------------|-------------------------------------
-| Name prefix used for auto-generated PVs            | (empty)           | CAENHVAsynSetEpicsPrefix(const char* prefix)
+| Parameter                                                 | Default value     | Function to set a new value
+|-----------------------------------------------------------|-------------------|-------------------------------------
+| Name prefix used for auto-generated PVs                   | (empty)           | CAENHVAsynSetEpicsPrefix(const char* prefix)
+| Read-only, if set to 1 only expose parameters for reading | 0                 | CAENHVAsynReadOnly(const int readOnly)
+
 
 You must call these functions in your **st.cmd** before calling **CAENHVAsynConfig**. The changes will apply to all instances of CAENHVAsyn you have in
 your application.


### PR DESCRIPTION
Adds a read only option that can be set when starting the IOC. This will then only expose the reading PVs, not the writing ones.

(Used at ISIS to guard against people accidentally setting things they shouldn't)