### PR TITLE
Fix SerNumList type for CAENHVWrapper 7.x

### DIFF
--- a/CAENHVAsynApp/src/crate.cpp
+++ b/CAENHVAsynApp/src/crate.cpp
@@ -93,7 +93,11 @@ void ICrate::GetCrateMap()
     unsigned short *NrOfChList;
     char *ModelList;
     char *DescriptionList;
+#if CAENHVLIB_VERSION_MAJOR >= 7
     unsigned int *SerNumList;
+#else
+    unsigned short *SerNumList;
+#endif
     unsigned char *FmwRelMinList;
     unsigned char *FmwRelMaxList;
 

--- a/CAENHVAsynApp/src/crate.cpp
+++ b/CAENHVAsynApp/src/crate.cpp
@@ -93,7 +93,7 @@ void ICrate::GetCrateMap()
     unsigned short *NrOfChList;
     char *ModelList;
     char *DescriptionList;
-    unsigned short *SerNumList;
+    unsigned int *SerNumList;
     unsigned char *FmwRelMinList;
     unsigned char *FmwRelMaxList;
 


### PR DESCRIPTION
This change is necessary to use with CAENHVWrapper 7.(2.1beta1)