### PR TITLE
Make SCAN, PINI and similar fields default arguments.

### DIFF
--- a/CAENHVAsynApp/Db/A1589-board.substitutions
+++ b/CAENHVAsynApp/Db/A1589-board.substitutions
@@ -1,0 +1,41 @@
+# CAEN A1589 8 channel +/-2.5 kV/500 uA quadrant bipolar board
+#
+# Required macros:
+#    P     - Prefix
+#    PORT  - Asyn port name
+#    SLOT  - Slot number, must be two digits ("01" for slot 1)
+#    SCAN  - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter           Type      Mode  Min   Max   Unit
+#    ----------------------------------------------------------------------
+#
+#    Status       S$(SLOT)_BDSTATUS        Int       RO      -     -      -
+#    HVMax        S$(SLOT)_HVMAX           Float     RO      0  3150      V
+#    Temp         S$(SLOT)_TEMP            Float     RO      5    65      C
+
+
+# Board status bits
+#    Bit 0:       Power-fail status
+#    Bit 1:       Firmware checksum error
+#    Bit 2:       HVMax calibration error
+#    Bit 3:       Temperature calibration error
+#    Bit 4:       Under-temperature (< 5 degrees C)
+#    Bit 5:       Over-temperature (> 65 degrees C)
+#    Bit 6-31:    Reserved, forced to 0
+file bi.template {
+    pattern { R,               PARAM,                DESC,                             ZNAM,  ONAM,   MASK,  SCAN    }
+            { "Status-PF",     "S$(SLOT)_BDSTATUS",  "Power fail",                     "No",  "Yes",  "1",   $(SCAN) }
+            { "Status-FCE",    "S$(SLOT)_BDSTATUS",  "Firmware checksum error",        "No",  "Yes",  "2",   $(SCAN) }
+            { "Status-CEHV",   "S$(SLOT)_BDSTATUS",  "HVMax calibration error",        "No",  "Yes",  "4",   $(SCAN) }
+            { "Status-CET",    "S$(SLOT)_BDSTATUS",  "Temperature calibration error",  "No",  "Yes",  "8",   $(SCAN) }
+            { "Status-UT",     "S$(SLOT)_BDSTATUS",  "Under temperature",              "No",  "Yes",  "16",  $(SCAN) }
+            { "Status-OT",     "S$(SLOT)_BDSTATUS",  "Over temperature",               "No",  "Yes",  "32",  $(SCAN) }
+}
+
+file ai.template {
+    pattern { R,               PARAM,                DESC,                              EGU,   LOPR,   HOPR,    SCAN    }
+            { "HVMax",         "S$(SLOT)_HVMAX",     "Hardware voltage limit",          "V",   "0",    "3150",  $(SCAN) }
+            { "Temp",          "S$(SLOT)_TEMP",      "Board temperature",               "C",   "5",    "65",    $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A1589-channel.substitutions
+++ b/CAENHVAsynApp/Db/A1589-channel.substitutions
@@ -1,0 +1,100 @@
+# CAEN A1589 +/-2.5 kV/500 uA quadrant bipolar channel
+#
+# Required macros:
+#    P       - Prefix
+#    PORT    - Asyn port name
+#    SLOT    - Slot number, must be two digits ("01" for slot 1)
+#    CHANNEL - Channel number, must be two digits ("01" for channel 1)
+#    SCAN    - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter                 Type      Mode  Min   Max   Unit
+#    -------------------------------------------------------------------------
+#    Status       S$(SLOT)_C$(CHANNEL)_STATUS    Int       RO      -     -      -
+#    V0Set        S$(SLOT)_C$(CHANNEL)_V0SET     Float     RW  -2500  2500      V
+#    I0Set        S$(SLOT)_C$(CHANNEL)_I0SET     Float     RW   -500   500     uA
+#    RUp          S$(SLOT)_C$(CHANNEL)_RUP       Float     RW      1   500    V/s
+#    RDWn         S$(SLOT)_C$(CHANNEL)_RDWN      Float     RW      1   500    V/s
+#    Trip         S$(SLOT)_C$(CHANNEL)_TRIP      Float     RW      0  1000      s
+#    SVMax        S$(SLOT)_C$(CHANNEL)_SVMAX     Float     RW  -2500  2500      V
+#    VMon         S$(SLOT)_C$(CHANNEL)_VMON      Float     RO      0  2500      V
+#    IMon         S$(SLOT)_C$(CHANNEL)_IMON      Float     RO      0   500     uA
+#    Pw           S$(SLOT)_C$(CHANNEL)_PW        Bool      RW      -     -      -
+#    PDwn         S$(SLOT)_C$(CHANNEL)_PDWN      Bool      RW      -     -      -
+#    TripInt      S$(SLOT)_C$(CHANNEL)_TRIPINT   Bool      RW      -     -      -
+#    TripExt      S$(SLOT)_C$(CHANNEL)_TRIPEXT   Bool      RW      -     -      -
+
+
+# Channel status bits
+#    Bit 0:       Channel is on
+#    Bit 1:       Channel is ramping up
+#    Bit 2:       Channel is ramping down
+#    Bit 3:       Overcurrent
+#    Bit 4:       Overvoltage
+#    Bit 5:       Undervoltage
+#    Bit 6:       External trip
+#    Bit 7:       Max voltage reached
+#    Bit 8:       External disable
+#    Bit 9:       Internal trip
+#    Bit 10:      Calibration error
+#    Bit 11:      Channel is unplugged
+#    Bit 12-31:   Reserved, forced to 0
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,  ONAM,   MASK,    SCAN    }
+            { "Status-ON",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Channel is On",               "No",  "Yes",  "1",     $(SCAN) }
+            { "Status-RU",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping up",                  "No",  "Yes",  "2",     $(SCAN) }
+            { "Status-RD",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping down",                "No",  "Yes",  "4",     $(SCAN) }
+            { "Status-OC",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overcurrent",                 "No",  "Yes",  "8",     $(SCAN) }
+            { "Status-OV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overvoltage",                 "No",  "Yes",  "16",    $(SCAN) }
+            { "Status-UV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Undervoltage",                "No",  "Yes",  "32",    $(SCAN) }
+            { "Status-ET",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External trip",               "No",  "Yes",  "64",    $(SCAN) }
+            { "Status-MV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Max voltage reached",         "No",  "Yes",  "128",   $(SCAN) }
+            { "Status-ED",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External disable",            "No",  "Yes",  "256",   $(SCAN) }
+            { "Status-IT",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Internal trip",               "No",  "Yes",  "512",   $(SCAN) }
+            { "Status-CE",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Calibration error",           "No",  "Yes",  "1024",  $(SCAN) }
+            { "Status-UN",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Unplugged",                   "No",  "Yes",  "2048",  $(SCAN) }
+}
+
+# Measurements
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,   LOPR,  HOPR,     SCAN    }
+            { "VMon",         "S$(SLOT)_C$(CHANNEL)_VMON",    "Monitored voltage",           "V",   "0",   "2500",   $(SCAN) }
+            { "IMon",         "S$(SLOT)_C$(CHANNEL)_IMON",    "Monitored current",           "uA",  "0",   "500",    $(SCAN) }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,     HOPR,    DRVL,     DRVH   }
+            { "V0Set",        "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "-2500",  "2500",  "-2500",  "2500" }
+            { "I0Set",        "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "-500",   "500",   "-500",   "500"  }
+            { "RUp",          "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",      "500",   "1",      "500"  }
+            { "RDwn",         "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",      "500",   "1",      "500"  }
+            { "Trip",         "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",      "1000",  "0",      "1000" }
+            { "SVMax",        "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "-2500",  "2500",  "-2500",  "2500" }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,     HOPR,    SCAN    }
+            { "V0Set-RB",     "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "-2500",  "2500",  $(SCAN) }
+            { "I0Set-RB",     "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "-500",   "500",   $(SCAN) }
+            { "RUp-RB",       "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",      "500",   $(SCAN) }
+            { "RDwn-RB",      "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",      "500",   $(SCAN) }
+            { "Trip-RB",      "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",      "1000",  $(SCAN) }
+            { "SVMax-RB",     "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "-2500",  "2500",  $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,    ONAM,    MASK }
+            { "Pw",           "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",   "On",    "1"  }
+            { "PDwn",         "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",  "Ramp",  "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,     ONAM,    MASK,  SCAN    }
+            { "Pw-RB",        "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",    "On",    "1",   $(SCAN) }
+            { "PDwn-RB",      "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",   "Ramp",  "1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A2519-board.substitutions
+++ b/CAENHVAsynApp/Db/A2519-board.substitutions
@@ -1,0 +1,68 @@
+# CAEN A2519 8-channel 5-15V / 5A power supply board
+#
+# Required macros:
+#    P     - Prefix
+#    PORT  - Asyn port name
+#    SLOT  - Slot number, must be two digits ("01" for slot 1)
+#    SCAN  - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter           Type      Mode  Min   Max   Unit
+#    ----------------------------------------------------------------------
+#
+#    BdStatus     S$(SLOT)_BDSTATUS        Int       RO      -     -      -
+#    OnGroup      S$(SLOT)_ONGROUP         Float     RW      0     4      -
+#    OffGroup     S$(SLOT)_OFFGROUP        Float     RW      0     4      -
+#    IntckA       S$(SLOT)_INTCKA          Bool      RW      -     -      -
+#    IntckB       S$(SLOT)_INTCKB          Bool      RW      -     -      -
+#    ClrAlarm     S$(SLOT)_CLRALARM        Bool      RW      -     -      -
+
+
+# Board status bits
+#    Bit 0:       Power-fail status
+#    Bit 1:       Firmware checksum error
+#    Bit 2:       HVMax calibration error
+#    Bit 3:       Temperature calibration error
+#    Bit 4:       Under-temperature (< 5 degrees C)
+#    Bit 5:       Over-temperature (> 64 degrees C)
+#    Bit 6-31:    Reserved, forced to 0
+file bi.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,  ONAM,   MASK,  SCAN    }
+            { "Status-PF",      "S$(SLOT)_BDSTATUS",  "Power fail",                     "No",  "Yes",  "1",   $(SCAN) }
+            { "Status-FCE",     "S$(SLOT)_BDSTATUS",  "Firmware checksum error",        "No",  "Yes",  "2",   $(SCAN) }
+            { "Status-CEHV",    "S$(SLOT)_BDSTATUS",  "HVMax calibration error",        "No",  "Yes",  "4",   $(SCAN) }
+            { "Status-CET",     "S$(SLOT)_BDSTATUS",  "Temperature calibration error",  "No",  "Yes",  "8",   $(SCAN) }
+            { "Status-UT",      "S$(SLOT)_BDSTATUS",  "Under temperature",              "No",  "Yes",  "16",  $(SCAN) }
+            { "Status-OT",      "S$(SLOT)_BDSTATUS",  "Over temperature",               "No",  "Yes",  "32",  $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,        ONAM,       MASK }
+            { "IntckA",         "S$(SLOT)_INTCKA",    "Section A interlock enable",     "Disabled",  "Enabled",  "1"  }
+            { "IntckB",         "S$(SLOT)_INTCKB",    "Section B interlock enable",     "Disabled",  "Enabled",  "1"  }
+            { "ClrAlarm",       "S$(SLOT)_CLRALARM",  "Clear board alarms",             "No",        "Yes",      "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,        ONAM,       MASK,  SCAN    }
+            { "IntckA-RB",      "S$(SLOT)_INTCKA",    "Section A interlock enable",     "Disabled",  "Enabled",  "1"    $(SCAN) }
+            { "IntckB-RB",      "S$(SLOT)_INTCKB",    "Section B interlock enable",     "Disabled",  "Enabled",  "1"    $(SCAN) }
+            { "ClrAlarm-RB",    "S$(SLOT)_CLRALARM",  "Clear board alarms",             "No",        "Yes",      "1",   $(SCAN) }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,                PARAM,                DESC,                             EGU, LOPR, HOPR, DRVL, DRVH }
+            { "OnGroup",        "S$(SLOT)_ONGROUP",   "Turn channel group on",          "",  "0",  "4",  "0",  "4"  }
+            { "OffGroup",       "S$(SLOT)_OFFGROUP",  "Turn channel group off",         "",  "0",  "4",  "0",  "4"  }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,                PARAM,                DESC,                             EGU, LOPR, HOPR, SCAN    }
+            { "OnGroup-RB",     "S$(SLOT)_ONGROUP",   "Turn channels group on",         "",  "0",  "4",  $(SCAN) }
+            { "OffGroup-RB",    "S$(SLOT)_OFFGROUP",  "Turn channels group off",        "",  "0",  "4",  $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A2519-channel.substitutions
+++ b/CAENHVAsynApp/Db/A2519-channel.substitutions
@@ -1,0 +1,110 @@
+# CAEN A2519 5-15V / 5A power supply channel
+#
+# Required macros:
+#    P       - Prefix
+#    PORT    - Asyn port name
+#    SLOT    - Slot number, must be two digits ("01" for slot 1)
+#    CHANNEL - Channel number, must be two digits ("01" for channel 1)
+#    SCAN    - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter                  Type      Mode  Min   Max  Unit
+#    ----------------------------------------------------------------------------
+#    Status       S$(SLOT)_C$(CHANNEL)_STATUS     Int       RO      -     -     -
+#    V0Set        S$(SLOT)_C$(CHANNEL)_V0SET      Float     RW      5    15     V
+#    I0Set        S$(SLOT)_C$(CHANNEL)_I0SET      Float     RW      0   5.2     A
+#    RUpTime      S$(SLOT)_C$(CHANNEL)_RUPTIME    Float     RW      0   200    ms
+#    RDwTime      S$(SLOT)_C$(CHANNEL)_RDWTIME    Float     RW      0   200    ms
+#    UNVThr       S$(SLOT)_C$(CHANNEL)_UNVTHR     Float     RW      4    16     V
+#    OVVThr       S$(SLOT)_C$(CHANNEL)_OVVTHR     Float     RW      4    16     V
+#    VMon         S$(SLOT)_C$(CHANNEL)_VMON       Float     RO      0    15     V
+#    VCon         S$(SLOT)_C$(CHANNEL)_VCON       Float     RO      0    15     V
+#    IMon         S$(SLOT)_C$(CHANNEL)_IMON       Float     RO      0  10.2     A
+#    Temp         S$(SLOT)_C$(CHANNEL)_TEMP       Float     RO      5    85     C
+#    ChToGroup    S$(SLOT)_C$(CHANNEL)_CHTOGROUP  Float     RW      0     4     -
+#    OnGrDel      S$(SLOT)_C$(CHANNEL)_ONGRDEL    Float     RW      0  1000    ms
+#    OffGrDel     S$(SLOT)_C$(CHANNEL)_OFFGRDEL   Float     RW      0  1000    ms
+#    Pw           S$(SLOT)_C$(CHANNEL)_PW         Bool      RW      -     -     -
+#    TripInt      S$(SLOT)_C$(CHANNEL)_TRIPINT    Int       RW      -     -     -
+#    TripExt      S$(SLOT)_C$(CHANNEL)_TRIPEXT    Int       RW      -     -     -
+
+
+# Channel status bits
+#    Bit 0:       Channel is on
+#    Bit 1:       Channel is ramping up
+#    Bit 2:       Channel is ramping down
+#    Bit 3:       Overcurrent
+#    Bit 4:       Overvoltage
+#    Bit 5:       Undervoltage
+#    Bit 6:       External trip
+#    Bit 7:       Max voltage reached
+#    Bit 8:       External disable
+#    Bit 9:       Internal trip
+#    Bit 10:      Calibration error
+#    Bit 11:      Channel is unplugged
+#    Bit 12-31:   Reserved, forced to 0
+file bi.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,  ONAM,   MASK,    SCAN    }
+            { "Status-ON",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Channel is On",                "No",  "Yes",  "1",     $(SCAN) }
+            { "Status-RU",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Ramping up",                   "No",  "Yes",  "2",     $(SCAN) }
+            { "Status-RD",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Ramping down",                 "No",  "Yes",  "4",     $(SCAN) }
+            { "Status-OC",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Overcurrent",                  "No",  "Yes",  "8",     $(SCAN) }
+            { "Status-OV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Overvoltage",                  "No",  "Yes",  "16",    $(SCAN) }
+            { "Status-UV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Undervoltage",                 "No",  "Yes",  "32",    $(SCAN) }
+            { "Status-ET",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "External trip",                "No",  "Yes",  "64",    $(SCAN) }
+            { "Status-MV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Max voltage reached",          "No",  "Yes",  "128",   $(SCAN) }
+            { "Status-ED",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "External disable",             "No",  "Yes",  "256",   $(SCAN) }
+            { "Status-IT",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Internal trip",                "No",  "Yes",  "512",   $(SCAN) }
+            { "Status-CE",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Calibration error",            "No",  "Yes",  "1024",  $(SCAN) }
+            { "Status-UN",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Unplugged",                    "No",  "Yes",  "2048",  $(SCAN) }
+}
+
+# Measurements
+file ai.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,   LOPR,  HOPR,    SCAN    }
+            { "VMon",         "S$(SLOT)_C$(CHANNEL)_VMON",       "Monitored voltage",            "V",   "0",   "15",    $(SCAN) }
+            { "VCon",         "S$(SLOT)_C$(CHANNEL)_VCON",       "Monitored connector voltage",  "V",   "0",   "15",    $(SCAN) }
+            { "IMon",         "S$(SLOT)_C$(CHANNEL)_IMON",       "Monitored current",            "A",   "0",   "10.2",  $(SCAN) }
+            { "Temp",         "S$(SLOT)_C$(CHANNEL)_TEMP",       "Channel Temperature",          "C",   "5",   "85",    $(SCAN) }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,   LOPR,  HOPR,    DRVL,  DRVH   }
+            { "V0Set",        "S$(SLOT)_C$(CHANNEL)_V0SET",      "First voltage setting",        "V",   "5",   "15",    "5",   "15"   }
+            { "I0Set",        "S$(SLOT)_C$(CHANNEL)_I0SET",      "First current limit",          "A",   "0",   "5.2",   "0",   "5.2"  }
+            { "RUpTime",      "S$(SLOT)_C$(CHANNEL)_RUPTIME",    "Ramp-up time",                 "ms",  "0",   "200",   "0",   "200"  }
+            { "RDwTime",      "S$(SLOT)_C$(CHANNEL)_RDWTIME",    "Ramp-down time",               "ms",  "0",   "200",   "0",   "200"  }
+            { "UNVThr",       "S$(SLOT)_C$(CHANNEL)_UNVTHR",     "Under-voltage threshold",      "V",   "4",   "16",    "4",   "16"   }
+            { "OVVThr",       "S$(SLOT)_C$(CHANNEL)_OVVTHR",     "Over-voltage threshold",       "V",   "4",   "16",    "4",   "16"   }
+            { "ChToGroup"     "S$(SLOT)_C$(CHANNEL)_CHTOGROUP",  "Group of this channel"         "",    "0",   "4",     "0",   "4"    }
+            { "OnGrDel"       "S$(SLOT)_C$(CHANNEL)_ONGRDEL",    "Group ON delay"                "ms",  "0",   "1000",  "0",   "1000" }
+            { "OffGrDel"      "S$(SLOT)_C$(CHANNEL)_OFFGRDEL",   "Group OFF delay"               "ms",  "0",   "1000",  "0",   "1000" }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,    LOPR,   HOPR,    SCAN    }
+            { "V0Set-RB",     "S$(SLOT)_C$(CHANNEL)_V0SET",      "First voltage setting",        "V",    "5",    "15",    $(SCAN) }
+            { "I0Set-RB",     "S$(SLOT)_C$(CHANNEL)_I0SET",      "First current limit",          "A",    "0",    "5.2",   $(SCAN) }
+            { "RUpTime-RB",   "S$(SLOT)_C$(CHANNEL)_RUPTIME",    "Ramp-up time",                 "ms",   "0",    "200",   $(SCAN) }
+            { "RDwTime-RB",   "S$(SLOT)_C$(CHANNEL)_RDWTIME",    "Ramp-down time",               "ms",   "0",    "200",   $(SCAN) }
+            { "UNVThr-RB",    "S$(SLOT)_C$(CHANNEL)_UNVTHR",     "Under-voltage threshold",      "V",    "4",    "16",    $(SCAN) }
+            { "OVVThr-RB",    "S$(SLOT)_C$(CHANNEL)_OVVTHR",     "Over-voltage threshold",       "V",    "4",    "16",    $(SCAN) }
+            { "ChToGroup-RB"  "S$(SLOT)_C$(CHANNEL)_CHTOGROUP",  "Group of this channel"         "",     "0",    "4",     $(SCAN) }
+            { "OnGrDel-RB"    "S$(SLOT)_C$(CHANNEL)_ONGRDEL",    "Group ON delay"                "ms",   "0",    "1000",  $(SCAN) }
+            { "OffGrDel-RB"   "S$(SLOT)_C$(CHANNEL)_OFFGRDEL",   "Group OFF delay"               "ms",   "0",    "1000",  $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,   ONAM,  MASK }
+            { "Pw",           "S$(SLOT)_C$(CHANNEL)_PW",         "Power on/off",                 "Off",  "On",  "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,   ONAM,  MASK,  SCAN    }
+            { "Pw-RB",        "S$(SLOT)_C$(CHANNEL)_PW",         "Power on/off",                 "Off",  "On",  "1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A2552-board.substitutions
+++ b/CAENHVAsynApp/Db/A2552-board.substitutions
@@ -1,0 +1,52 @@
+# CAEN A2552 8-channel 0-16V / 6A power supply board
+#
+# Required macros:
+#    P     - Prefix
+#    PORT  - Asyn port name
+#    SLOT  - Slot number, must be two digits ("01" for slot 1)
+#    SCAN  - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter           Type      Mode  Min   Max   Unit
+#    ----------------------------------------------------------------------
+#
+#    BdStatus     S$(SLOT)_BDSTATUS        Int       RO      -     -      -
+#    IntckA       S$(SLOT)_INTCKA          Bool      RW      -     -      -
+#    IntckB       S$(SLOT)_INTCKB          Bool      RW      -     -      -
+#    ClrAlarm     S$(SLOT)_CLRALARM        Bool      RW      -     -      -
+
+
+# Board status bits
+#    Bit 0:       Power-fail status
+#    Bit 1:       Firmware checksum error
+#    Bit 2:       HVMax calibration error
+#    Bit 3:       Temperature calibration error
+#    Bit 4:       Under-temperature (< 5 degrees C)
+#    Bit 5:       Over-temperature (> 65 degrees C)
+#    Bit 6-31:    Reserved, forced to 0
+file bi.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,  ONAM,   MASK,  SCAN    }
+            { "Status-PF",      "S$(SLOT)_BDSTATUS",  "Power fail",                     "No",  "Yes",  "1",   $(SCAN) }
+            { "Status-FCE",     "S$(SLOT)_BDSTATUS",  "Firmware checksum error",        "No",  "Yes",  "2",   $(SCAN) }
+            { "Status-CEHV",    "S$(SLOT)_BDSTATUS",  "HVMax calibration error",        "No",  "Yes",  "4",   $(SCAN) }
+            { "Status-CET",     "S$(SLOT)_BDSTATUS",  "Temperature calibration error",  "No",  "Yes",  "8",   $(SCAN) }
+            { "Status-UT",      "S$(SLOT)_BDSTATUS",  "Under temperature",              "No",  "Yes",  "16",  $(SCAN) }
+            { "Status-OT",      "S$(SLOT)_BDSTATUS",  "Over temperature",               "No",  "Yes",  "32",  $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,        ONAM,       MASK }
+            { "IntckA",         "S$(SLOT)_INTCKA",    "Section A interlock enable",     "Disabled",  "Enabled",  "1"  }
+            { "IntckB",         "S$(SLOT)_INTCKB",    "Section B interlock enable",     "Disabled",  "Enabled",  "1"  }
+            { "ClrAlarm",       "S$(SLOT)_CLRALARM",  "Clear board alarms",             "No",        "Yes",      "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,                PARAM,                DESC,                             ZNAM,        ONAM,       MASK,  SCAN    }
+            { "IntckA-RB",      "S$(SLOT)_INTCKA",    "Section A interlock enable",     "Disabled",  "Enabled",  "1"    $(SCAN) }
+            { "IntckB-RB",      "S$(SLOT)_INTCKB",    "Section B interlock enable",     "Disabled",  "Enabled",  "1"    $(SCAN) }
+            { "ClrAlarm-RB",    "S$(SLOT)_CLRALARM",  "Clear board alarms",             "No",        "Yes",      "1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A2552-channel.substitutions
+++ b/CAENHVAsynApp/Db/A2552-channel.substitutions
@@ -1,0 +1,109 @@
+# CAEN A2552 0-16V / 6A power supply channel
+#
+# Required macros:
+#    P       - Prefix
+#    PORT    - Asyn port name
+#    SLOT    - Slot number, must be two digits ("01" for slot 1)
+#    CHANNEL - Channel number, must be two digits ("01" for channel 1)
+#    SCAN    - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter                  Type      Mode  Min   Max  Unit
+#    ----------------------------------------------------------------------------
+#    Status       S$(SLOT)_C$(CHANNEL)_STATUS     Int       RO      -     -     -
+#    V0Set        S$(SLOT)_C$(CHANNEL)_V0SET      Float     RW      0    16     V
+#    I0Set        S$(SLOT)_C$(CHANNEL)_I0SET      Float     RW      0     6     A
+#    RUp          S$(SLOT)_C$(CHANNEL)_RUP        Float     RW      1   500    ms
+#    RDWn         S$(SLOT)_C$(CHANNEL)_RDWN       Float     RW      1   500    ms
+#    Trip         S$(SLOT)_C$(CHANNEL)_TRIP       Float     RW      0  1000    ms
+#    UNVThr       S$(SLOT)_C$(CHANNEL)_UNVTHR     Float     RW      0    17     V
+#    OVVThr       S$(SLOT)_C$(CHANNEL)_OVVTHR     Float     RW      0    17     V
+#    VMon         S$(SLOT)_C$(CHANNEL)_VMON       Float     RO      0    16     V
+#    VCon         S$(SLOT)_C$(CHANNEL)_VCON       Float     RO      0    19     V
+#    IMon         S$(SLOT)_C$(CHANNEL)_IMON       Float     RO      0     6     A
+#    Temp         S$(SLOT)_C$(CHANNEL)_TEMP       Float     RO      5    65     C
+#    FwRel        S$(SLOT)_C$(CHANNEL)_FWREL      Float     RO      0    10     Vr
+#    Pw           S$(SLOT)_C$(CHANNEL)_PW         Bool      RW      -     -     -
+#    PDwn         S$(SLOT)_C$(CHANNEL)_PDWN       Bool      RW      -     -     -
+#    TripInt      S$(SLOT)_C$(CHANNEL)_TRIPINT    Int       RW      -     -     -
+#    TripExt      S$(SLOT)_C$(CHANNEL)_TRIPEXT    Int       RW      -     -     -
+
+
+# Channel status bits
+#    Bit 0:       Channel is on
+#    Bit 1:       Channel is ramping up
+#    Bit 2:       Channel is ramping down
+#    Bit 3:       Overcurrent
+#    Bit 4:       Overvoltage
+#    Bit 5:       Undervoltage
+#    Bit 6:       External trip
+#    Bit 7:       Max voltage reached
+#    Bit 8:       External disable
+#    Bit 9:       Internal trip
+#    Bit 10:      Calibration error
+#    Bit 11:      Channel is unplugged
+#    Bit 12-31:   Reserved, forced to 0
+file bi.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,  ONAM,   MASK,    SCAN    }
+            { "Status-ON",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Channel is On",                "No",  "Yes",  "1",     $(SCAN) }
+            { "Status-RU",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Ramping up",                   "No",  "Yes",  "2",     $(SCAN) }
+            { "Status-RD",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Ramping down",                 "No",  "Yes",  "4",     $(SCAN) }
+            { "Status-OC",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Overcurrent",                  "No",  "Yes",  "8",     $(SCAN) }
+            { "Status-OV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Overvoltage",                  "No",  "Yes",  "16",    $(SCAN) }
+            { "Status-UV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Undervoltage",                 "No",  "Yes",  "32",    $(SCAN) }
+            { "Status-ET",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "External trip",                "No",  "Yes",  "64",    $(SCAN) }
+            { "Status-MV",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Max voltage reached",          "No",  "Yes",  "128",   $(SCAN) }
+            { "Status-ED",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "External disable",             "No",  "Yes",  "256",   $(SCAN) }
+            { "Status-IT",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Internal trip",                "No",  "Yes",  "512",   $(SCAN) }
+            { "Status-CE",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Calibration error",            "No",  "Yes",  "1024",  $(SCAN) }
+            { "Status-UN",    "S$(SLOT)_C$(CHANNEL)_STATUS",     "Unplugged",                    "No",  "Yes",  "2048",  $(SCAN) }
+}
+
+# Measurements
+file ai.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,   LOPR,  HOPR,    SCAN,    PREC, }
+            { "VMon",         "S$(SLOT)_C$(CHANNEL)_VMON",       "Monitored voltage",            "V",   "0",   "16",    $(SCAN), "2"   }
+            { "VCon",         "S$(SLOT)_C$(CHANNEL)_VCON",       "Monitored connector voltage",  "V",   "0",   "19",    $(SCAN), "2"   }
+            { "IMon",         "S$(SLOT)_C$(CHANNEL)_IMON",       "Monitored current",            "A",   "0",   "6",     $(SCAN), "4"   }
+            { "Temp",         "S$(SLOT)_C$(CHANNEL)_TEMP",       "Channel Temperature",          "C",   "5",   "65",    $(SCAN), "2"   }
+            { "FwRel",        "S$(SLOT)_C$(CHANNEL)_FWREL",      "Firmware release",             "Vr",  "0",   "10",    $(SCAN), "2"   }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,   LOPR,  HOPR,    DRVL,  DRVH   }
+            { "V0Set",        "S$(SLOT)_C$(CHANNEL)_V0SET",      "First voltage setting",        "V",   "0",   "16",    "0",   "16"   }
+            { "I0Set",        "S$(SLOT)_C$(CHANNEL)_I0SET",      "First current limit",          "A",   "0",   "6",     "0",   "6"    }
+            { "RUp",          "S$(SLOT)_C$(CHANNEL)_RUP",        "Ramp-up time",                 "ms",  "1",   "500",   "1",   "500"  }
+            { "RDwn",         "S$(SLOT)_C$(CHANNEL)_RDWN",       "Ramp-down time",               "ms",  "1",   "500",   "1",   "500"  }
+            { "Trip",         "S$(SLOT)_C$(CHANNEL)_TRIP",       "Trip limit",                   "ms",  "0",   "1000",  "0",   "1000" }
+            { "UNVThr",       "S$(SLOT)_C$(CHANNEL)_UNVTHR",     "Under-voltage threshold",      "V",   "0",   "17",    "0",   "17"   }
+            { "OVVThr",       "S$(SLOT)_C$(CHANNEL)_OVVTHR",     "Over-voltage threshold",       "V",   "0",   "17",    "0",   "17"   }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,              PARAM,                             DESC,                           EGU,    LOPR,   HOPR,    SCAN    }
+            { "V0Set-RB",     "S$(SLOT)_C$(CHANNEL)_V0SET",      "First voltage setting",        "V",    "0",    "16",    $(SCAN) }
+            { "I0Set-RB",     "S$(SLOT)_C$(CHANNEL)_I0SET",      "First current limit",          "A",    "0",    "6",     $(SCAN) }
+            { "RUp-RB",       "S$(SLOT)_C$(CHANNEL)_RUP",        "Ramp-up time",                 "ms",   "1",    "500",   $(SCAN) }
+            { "RDwn-RB",      "S$(SLOT)_C$(CHANNEL)_RDWN",       "Ramp-down time",               "ms",   "1",    "500",   $(SCAN) }
+            { "Trip-RB",      "S$(SLOT)_C$(CHANNEL)_TRIP",       "Trip time limit",              "ms",   "0",    "1000",  $(SCAN) }
+            { "UNVThr-RB",    "S$(SLOT)_C$(CHANNEL)_UNVTHR",     "Under-voltage threshold",      "V",    "0",    "17",    $(SCAN) }
+            { "OVVThr-RB",    "S$(SLOT)_C$(CHANNEL)_OVVTHR",     "Over-voltage threshold",       "V",    "0",    "17",    $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,   ONAM,  MASK }
+            { "Pw",           "S$(SLOT)_C$(CHANNEL)_PW",         "Power on/off",                 "Off",  "On",  "1"  }
+            { "PDwn",         "S$(SLOT)_C$(CHANNEL)_PDWN",       "Power down mode",              "Kill", "Ramp","1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,              PARAM,                             DESC,                           ZNAM,   ONAM,  MASK,  SCAN    }
+            { "Pw-RB",        "S$(SLOT)_C$(CHANNEL)_PW",         "Power on/off",                 "Off",  "On",  "1",   $(SCAN) }
+            { "PDwn-RB",      "S$(SLOT)_C$(CHANNEL)_PDWN",       "Power down mode",              "Kill", "Ramp","1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A7030-board.substitutions
+++ b/CAENHVAsynApp/Db/A7030-board.substitutions
@@ -1,0 +1,54 @@
+# CAEN A7030 12/24/36/48 channel 3 kV/1 mA power supply board
+#
+# Required macros:
+#    P     - Prefix
+#    PORT  - Asyn port name
+#    SLOT  - Slot number, must be two digits ("01" for slot 1)
+#    SCAN  - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter           Type      Mode  Min   Max   Unit
+#    ----------------------------------------------------------------------
+#
+#    Status       S$(SLOT)_BDSTATUS        Int       RO      -     -      -
+#    HVMax        S$(SLOT)_HVMAX           Float     RO      0  3200      V
+#    HIMax        S$(SLOT)_HIMAX           Float     RO      0  1050     uA
+#    Temp         S$(SLOT)_TEMP            Float     RO      5    65      C
+#    ClrAlarm     S$(SLOT)_CLRALARM        Bool      RW      -     -      -
+
+
+# Board status bits
+#    Bit 0:       Power-fail status
+#    Bit 1:       Firmware checksum error
+#    Bit 2:       HVMax calibration error
+#    Bit 3:       Temperature calibration error
+#    Bit 4:       Under-temperature (< 5 degrees C)
+#    Bit 5:       Over-temperature (> 64 degrees C)
+#    Bit 6-31:    Reserved, forced to 0
+file bi.template {
+    pattern { R,               PARAM,                DESC,                             ZNAM,  ONAM,   MASK,  SCAN    }
+            { "Status-PF",     "S$(SLOT)_BDSTATUS",  "Power fail",                     "No",  "Yes",  "1",   $(SCAN) }
+            { "Status-FCE",    "S$(SLOT)_BDSTATUS",  "Firmware checksum error",        "No",  "Yes",  "2",   $(SCAN) }
+            { "Status-CEHV",   "S$(SLOT)_BDSTATUS",  "HVMax calibration error",        "No",  "Yes",  "4",   $(SCAN) }
+            { "Status-CET",    "S$(SLOT)_BDSTATUS",  "Temperature calibration error",  "No",  "Yes",  "8",   $(SCAN) }
+            { "Status-UT",     "S$(SLOT)_BDSTATUS",  "Under temperature",              "No",  "Yes",  "16",  $(SCAN) }
+            { "Status-OT",     "S$(SLOT)_BDSTATUS",  "Over temperature",               "No",  "Yes",  "32",  $(SCAN) }
+}
+
+file ai.template {
+    pattern { R,               PARAM,                DESC,                              EGU,   LOPR,   HOPR,    SCAN    }
+            { "HIMax",         "S$(SLOT)_HIMAX",     "Hardware current limit",          "uA",  "0",    "1050",  $(SCAN) }
+            { "HVMax",         "S$(SLOT)_HVMAX",     "Hardware voltage limit",          "V",   "0",    "3200",  $(SCAN) }
+            { "Temp",          "S$(SLOT)_TEMP",      "Board temperature",               "C",   "5",    "65",    $(SCAN) }
+}
+
+file bo.template {
+    pattern { R,               PARAM,                DESC,                              ZNAM,  ONAM,   MASK }
+            { "ClrAlarm",      "S$(SLOT)_CLRALARM",  "Clear board alarms",              "No",  "Yes",  "1"  }
+}
+
+file bi.template {
+    pattern { R,               PARAM,                DESC,                              ZNAM,  ONAM,   MASK,    SCAN    }
+            { "ClrAlarm-RB",   "S$(SLOT)_CLRALARM",  "Clear board alarms",              "No",  "Yes",  "1",     $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A7030-channel.substitutions
+++ b/CAENHVAsynApp/Db/A7030-channel.substitutions
@@ -1,0 +1,112 @@
+# CAEN A7030 3 kV/1 mA power supply channel
+#
+# Required macros:
+#    P       - Prefix
+#    PORT    - Asyn port name
+#    SLOT    - Slot number, must be two digits ("01" for slot 1)
+#    CHANNEL - Channel number, must be two digits ("01" for channel 1)
+#    SCAN    - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter                 Type      Mode  Min   Max   Unit
+#    -------------------------------------------------------------------------
+#    Status       S$(SLOT)_C$(CHANNEL)_STATUS    Int       RO      -     -      -
+#    V0Set        S$(SLOT)_C$(CHANNEL)_V0SET     Float     RW      0  3000      V
+#    I0Set        S$(SLOT)_C$(CHANNEL)_I0SET     Float     RW      0  1010     uA
+#    V1Set        S$(SLOT)_C$(CHANNEL)_V1SET     Float     RW      0  3000      V
+#    I1Set        S$(SLOT)_C$(CHANNEL)_I1SET     Float     RW      0  1010     uA
+#    RUp          S$(SLOT)_C$(CHANNEL)_RUP       Float     RW      1   500    V/s
+#    RDWn         S$(SLOT)_C$(CHANNEL)_RDWN      Float     RW      1   500    V/s
+#    Trip         S$(SLOT)_C$(CHANNEL)_TRIP      Float     RW      0  1000      s
+#    SVMax        S$(SLOT)_C$(CHANNEL)_SVMAX     Float     RW      0  3000      V
+#    VMon         S$(SLOT)_C$(CHANNEL)_VMON      Float     RO      0  3000      V
+#    IMon         S$(SLOT)_C$(CHANNEL)_IMON      Float     RO      0  1000     uA
+#    ImAdj        S$(SLOT)_C$(CHANNEL)_IMADJ     Float     RW    -10    10     uA
+#    Pw           S$(SLOT)_C$(CHANNEL)_PW        Bool      RW      -     -      -
+#    POn          S$(SLOT)_C$(CHANNEL)_PON       Bool      RW      -     -      -
+#    PDwn         S$(SLOT)_C$(CHANNEL)_PDWN      Bool      RW      -     -      -
+#    TripInt      S$(SLOT)_C$(CHANNEL)_TRIPINT   Bool      RW      -     -      -
+#    TripExt      S$(SLOT)_C$(CHANNEL)_TRIPEXT   Bool      RW      -     -      -
+
+
+# Channel status bits
+#    Bit 0:       Channel is on
+#    Bit 1:       Channel is ramping up
+#    Bit 2:       Channel is ramping down
+#    Bit 3:       Overcurrent
+#    Bit 4:       Overvoltage
+#    Bit 5:       Undervoltage
+#    Bit 6:       External trip
+#    Bit 7:       Max voltage reached
+#    Bit 8:       External disable
+#    Bit 9:       Internal trip
+#    Bit 10:      Calibration error
+#    Bit 11:      Channel is unplugged
+#    Bit 12-31:   Reserved, forced to 0
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,  ONAM,   MASK,    SCAN    }
+            { "Status-ON",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Channel is On",               "No",  "Yes",  "1",     $(SCAN) }
+            { "Status-RU",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping up",                  "No",  "Yes",  "2",     $(SCAN) }
+            { "Status-RD",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping down",                "No",  "Yes",  "4",     $(SCAN) }
+            { "Status-OC",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overcurrent",                 "No",  "Yes",  "8",     $(SCAN) }
+            { "Status-OV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overvoltage",                 "No",  "Yes",  "16",    $(SCAN) }
+            { "Status-UV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Undervoltage",                "No",  "Yes",  "32",    $(SCAN) }
+            { "Status-ET",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External trip",               "No",  "Yes",  "64",    $(SCAN) }
+            { "Status-MV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Max voltage reached",         "No",  "Yes",  "128",   $(SCAN) }
+            { "Status-ED",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External disable",            "No",  "Yes",  "256",   $(SCAN) }
+            { "Status-IT",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Internal trip",               "No",  "Yes",  "512",   $(SCAN) }
+            { "Status-CE",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Calibration error",           "No",  "Yes",  "1024",  $(SCAN) }
+            { "Status-UN",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Unplugged",                   "No",  "Yes",  "2048",  $(SCAN) }
+}
+
+# Measurements
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,   LOPR,  HOPR,     SCAN    }
+            { "VMon",         "S$(SLOT)_C$(CHANNEL)_VMON",    "Monitored voltage",           "V",   "0",   "3000",   $(SCAN) }
+            { "IMon",         "S$(SLOT)_C$(CHANNEL)_IMON",    "Monitored current",           "uA",  "0",   "1000",   $(SCAN) }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,   HOPR,    DRVL,   DRVH   }
+            { "V0Set",        "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "0",    "3000",  "0",    "3000" }
+            { "V1Set",        "S$(SLOT)_C$(CHANNEL)_V1SET",   "Second voltage setting",      "V",    "0",    "3000",  "0",    "3000" }
+            { "I0Set",        "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "0",    "1010",  "0",    "1010" }
+            { "I1Set",        "S$(SLOT)_C$(CHANNEL)_I1SET",   "Second current limit",        "uA",   "0",    "1010",  "0",    "1010" }
+            { "RUp",          "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",    "500",   "1",    "500"  }
+            { "RDwn",         "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",    "500",   "1",    "500"  }
+            { "Trip",         "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",    "1000",  "0",    "1000" }
+            { "SVMax",        "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "0",    "3000",  "0",    "3000" }
+            { "ImAdj",        "S$(SLOT)_C$(CHANNEL)_IMADJ",   "Current monitor adjustment",  "uA",   "-10",  "10",    "-10",  "10"   }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,   HOPR,    SCAN    }
+            { "V0Set-RB",     "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "0",    "3000",  $(SCAN) }
+            { "V1Set-RB",     "S$(SLOT)_C$(CHANNEL)_V1SET",   "Second voltage setting",      "V",    "0",    "3000",  $(SCAN) }
+            { "I0Set-RB",     "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "0",    "1010",  $(SCAN) }
+            { "I1Set-RB",     "S$(SLOT)_C$(CHANNEL)_I1SET",   "Second current limit",        "uA",   "0",    "1010",  $(SCAN) }
+            { "RUp-RB",       "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",    "500",   $(SCAN) }
+            { "RDwn-RB",      "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",    "500",   $(SCAN) }
+            { "Trip-RB",      "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",    "1000",  $(SCAN) }
+            { "SVMax-RB",     "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "0",    "3000",  $(SCAN) }
+            { "ImAdj-RB",     "S$(SLOT)_C$(CHANNEL)_IMADJ",   "Current monitor adjustment",  "uA",   "-10",  "10",    $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,        ONAM,       MASK }
+            { "Pw",           "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",       "On",       "1"  }
+            { "POn",          "S$(SLOT)_C$(CHANNEL)_PON",     "Power-on option",             "Disabled",  "Enabled",  "1"  }
+            { "PDwn",         "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",      "Ramp",     "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,        ONAM,       MASK,  SCAN    }
+            { "Pw-RB",        "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",       "On",       "1",   $(SCAN) }
+            { "POn-RB",       "S$(SLOT)_C$(CHANNEL)_PON",     "Power-on option",             "Disabled",  "Enabled",  "1",   $(SCAN) }
+            { "PDwn-RB",      "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",      "Ramp",     "1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/A7030DP-channel.substitutions
+++ b/CAENHVAsynApp/Db/A7030DP-channel.substitutions
@@ -1,0 +1,115 @@
+# CAEN A7030DP 3 kV/1 mA power supply channel
+#
+# Required macros:
+#    P       - Prefix
+#    PORT    - Asyn port name
+#    SLOT    - Slot number, must be two digits ("01" for slot 1)
+#    CHANNEL - Channel number, must be two digits ("01" for channel 1)
+#    SCAN    - SCAN interval for input records
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name         Asyn parameter                 Type      Mode  Min   Max   Unit
+#    -------------------------------------------------------------------------
+#    Status       S$(SLOT)_C$(CHANNEL)_STATUS    Int       RO      -     -      -
+#    V0Set        S$(SLOT)_C$(CHANNEL)_V0SET     Float     RW      0  3000      V
+#    I0Set        S$(SLOT)_C$(CHANNEL)_I0SET     Float     RW      0  1010     uA
+#    V1Set        S$(SLOT)_C$(CHANNEL)_V1SET     Float     RW      0  3000      V
+#    I1Set        S$(SLOT)_C$(CHANNEL)_I1SET     Float     RW      0  1010     uA
+#    RUp          S$(SLOT)_C$(CHANNEL)_RUP       Float     RW      1   500    V/s
+#    RDWn         S$(SLOT)_C$(CHANNEL)_RDWN      Float     RW      1   500    V/s
+#    Trip         S$(SLOT)_C$(CHANNEL)_TRIP      Float     RW      0  1000      s
+#    SVMax        S$(SLOT)_C$(CHANNEL)_SVMAX     Float     RW      0  3000      V
+#    VMon         S$(SLOT)_C$(CHANNEL)_VMON      Float     RO      0  3000      V
+#    IMon         S$(SLOT)_C$(CHANNEL)_IMON      Float     RO      0  1000     uA
+#    Pw           S$(SLOT)_C$(CHANNEL)_PW        Bool      RW      -     -      -
+#    POn          S$(SLOT)_C$(CHANNEL)_PON       Bool      RW      -     -      -
+#    PDwn         S$(SLOT)_C$(CHANNEL)_PDWN      Bool      RW      -     -      -
+#    ZCDetect     S$(SLOT)_C$(CHANNEL)_ZCDETECT  Bool      RW      -     -      -
+#    ZCAdjust     S$(SLOT)_C$(CHANNEL)_ZCADJUST  Bool      RW      -     -      -
+#    TripInt      S$(SLOT)_C$(CHANNEL)_TRIPINT   Bool      RW      -     -      -
+#    TripExt      S$(SLOT)_C$(CHANNEL)_TRIPEXT   Bool      RW      -     -      -
+
+
+# Channel status bits
+#    Bit 0:       Channel is on
+#    Bit 1:       Channel is ramping up
+#    Bit 2:       Channel is ramping down
+#    Bit 3:       Overcurrent
+#    Bit 4:       Overvoltage
+#    Bit 5:       Undervoltage
+#    Bit 6:       External trip
+#    Bit 7:       Max voltage reached
+#    Bit 8:       External disable
+#    Bit 9:       Internal trip
+#    Bit 10:      Calibration error
+#    Bit 11:      Channel is unplugged
+#    Bit 12-31:   Reserved, forced to 0
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,  ONAM,   MASK,    SCAN    }
+            { "Status-ON",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Channel is On",               "No",  "Yes",  "1",     $(SCAN) }
+            { "Status-RU",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping up",                  "No",  "Yes",  "2",     $(SCAN) }
+            { "Status-RD",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Ramping down",                "No",  "Yes",  "4",     $(SCAN) }
+            { "Status-OC",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overcurrent",                 "No",  "Yes",  "8",     $(SCAN) }
+            { "Status-OV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Overvoltage",                 "No",  "Yes",  "16",    $(SCAN) }
+            { "Status-UV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Undervoltage",                "No",  "Yes",  "32",    $(SCAN) }
+            { "Status-ET",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External trip",               "No",  "Yes",  "64",    $(SCAN) }
+            { "Status-MV",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Max voltage reached",         "No",  "Yes",  "128",   $(SCAN) }
+            { "Status-ED",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "External disable",            "No",  "Yes",  "256",   $(SCAN) }
+            { "Status-IT",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Internal trip",               "No",  "Yes",  "512",   $(SCAN) }
+            { "Status-CE",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Calibration error",           "No",  "Yes",  "1024",  $(SCAN) }
+            { "Status-UN",    "S$(SLOT)_C$(CHANNEL)_STATUS",  "Unplugged",                   "No",  "Yes",  "2048",  $(SCAN) }
+}
+
+# Measurements
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,   LOPR,  HOPR,     SCAN    }
+            { "VMon",         "S$(SLOT)_C$(CHANNEL)_VMON",    "Monitored voltage",           "V",   "0",   "3000",   $(SCAN) }
+            { "IMon",         "S$(SLOT)_C$(CHANNEL)_IMON",    "Monitored current",           "uA",  "0",   "1000",   $(SCAN) }
+}
+
+# Numeric settings
+file ao.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,   HOPR,    DRVL,   DRVH   }
+            { "V0Set",        "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "0",    "3000",  "0",    "3000" }
+            { "V1Set",        "S$(SLOT)_C$(CHANNEL)_V1SET",   "Second voltage setting",      "V",    "0",    "3000",  "0",    "3000" }
+            { "I0Set",        "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "0",    "1010",  "0",    "1010" }
+            { "I1Set",        "S$(SLOT)_C$(CHANNEL)_I1SET",   "Second current limit",        "uA",   "0",    "1010",  "0",    "1010" }
+            { "RUp",          "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",    "500",   "1",    "500"  }
+            { "RDwn",         "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",    "500",   "1",    "500"  }
+            { "Trip",         "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",    "1000",  "0",    "1000" }
+            { "SVMax",        "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "0",    "3000",  "0",    "3000" }
+}
+
+# Numeric settings - readback
+file ai.template {
+    pattern { R,              PARAM,                          DESC,                          EGU,    LOPR,   HOPR,    SCAN    }
+            { "V0Set-RB",     "S$(SLOT)_C$(CHANNEL)_V0SET",   "First voltage setting",       "V",    "0",    "3000",  $(SCAN) }
+            { "V1Set-RB",     "S$(SLOT)_C$(CHANNEL)_V1SET",   "Second voltage setting",      "V",    "0",    "3000",  $(SCAN) }
+            { "I0Set-RB",     "S$(SLOT)_C$(CHANNEL)_I0SET",   "First current limit",         "uA",   "0",    "1010",  $(SCAN) }
+            { "I1Set-RB",     "S$(SLOT)_C$(CHANNEL)_I1SET",   "Second current limit",        "uA",   "0",    "1010",  $(SCAN) }
+            { "RUp-RB",       "S$(SLOT)_C$(CHANNEL)_RUP",     "Ramp-up speed",               "V/s",  "1",    "500",   $(SCAN) }
+            { "RDwn-RB",      "S$(SLOT)_C$(CHANNEL)_RDWN",    "Ramp-down speed",             "V/s",  "1",    "500",   $(SCAN) }
+            { "Trip-RB",      "S$(SLOT)_C$(CHANNEL)_TRIP",    "Overcurrent trip time",       "s",    "0",    "1000",  $(SCAN) }
+            { "SVMax-RB",     "S$(SLOT)_C$(CHANNEL)_SVMAX",   "Software voltage limit",      "V",    "0",    "3000",  $(SCAN) }
+}
+
+# Boolean settings
+file bo.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,        ONAM,       MASK }
+            { "Pw",           "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",       "On",       "1"  }
+            { "POn",          "S$(SLOT)_C$(CHANNEL)_PON",     "Power-on option",             "Disabled",  "Enabled",  "1"  }
+            { "PDwn",         "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",      "Ramp",     "1"  }
+            { "ZCDetect",     "S$(SLOT)_C$(CHANNEL)_ZCDETECT","Leakage current detection",   "Off",       "On",       "1"  }
+            { "ZCAdjust",     "S$(SLOT)_C$(CHANNEL)_ZCADJUST","Compensate leakage current",  "Disabled",  "Enabled",  "1"  }
+}
+
+# Boolean settings - readback
+file bi.template {
+    pattern { R,              PARAM,                          DESC,                          ZNAM,        ONAM,       MASK,  SCAN    }
+            { "Pw-RB",        "S$(SLOT)_C$(CHANNEL)_PW",      "Power on/off",                "Off",       "On",       "1",   $(SCAN) }
+            { "POn-RB",       "S$(SLOT)_C$(CHANNEL)_PON",     "Power-on option",             "Disabled",  "Enabled",  "1",   $(SCAN) }
+            { "PDwn-RB",      "S$(SLOT)_C$(CHANNEL)_PDWN",    "Power-down option",           "Kill",      "Ramp",     "1",   $(SCAN) }
+            { "ZCDetect-RB",  "S$(SLOT)_C$(CHANNEL)_ZCDETECT","Leakage current detection",   "Off",       "On",       "1",   $(SCAN) }
+            { "ZCAdjust-RB",  "S$(SLOT)_C$(CHANNEL)_ZCADJUST","Leakage current compensation","Disabled",  "Enabled",  "1",   $(SCAN) }
+}

--- a/CAENHVAsynApp/Db/Makefile
+++ b/CAENHVAsynApp/Db/Makefile
@@ -21,6 +21,17 @@ DB += longin.template
 DB += longout.template
 DB += reconnection.db
 
+DB += A1589-board.substitutions
+DB += A1589-channel.substitutions
+DB += A2519-board.substitutions
+DB += A2519-channel.substitutions
+DB += A2552-board.substitutions
+DB += A2552-channel.substitutions
+DB += A7030-board.substitutions
+DB += A7030-channel.substitutions
+DB += A7030DP-channel.substitutions
+DB += SYx527.substitutions
+
 #----------------------------------------------------
 # If <anyname>.db template is not named <anyname>*.template add
 # <anyname>_template = <templatename>

--- a/CAENHVAsynApp/Db/SYx527.substitutions
+++ b/CAENHVAsynApp/Db/SYx527.substitutions
@@ -1,0 +1,55 @@
+# CAEN SY4527/SY5527 power supply system
+#
+# Required macros:
+#    P     - Prefix
+#    PORT  - Asyn port name
+#
+# Available Parameters (extracted from debug dump file "CAENHVAsyn_CaenPort_crateInfo.txt")
+#
+#    Name             Asyn parameter           Type      Mode
+#    --------------------------------------------------------
+#    GenSignCfg       C_GENSIGNCFG             Int       RW
+#    FrontPanIn       C_FRONTPANIN             Int       RO
+#    FrontPanOut      C_FRONTPANOUT            Int       RO
+#    ResFlagCfg       C_RESFLAGCFG             Int       RW
+#    ResFlag          C_RESFLAG                Int       RO
+#    ClkFreq          C_CLKFREQ                Int       RO
+#    OutputLevel      C_OUTPUTLEVEL            Int       RW
+#    CmdQueueStatus   C_CMDQUEUESTATUS         Int       RO
+#    HVFanSpeed       C_HVFANSPEED             Int       RW
+#    DummyReg         C_DUMMYREG               Int       RW
+#    CMDExecMode      C_CMDEXECMODE            Int       RW
+#    Sessions         C_SESSIONS               String    RO
+#    ModelName        C_MODELNAME              String    RO
+#    SwRelease        C_SWRELEASE              String    RO
+#    HvPwSM           C_HVPWSM                 String    RO
+#    HVFanStat        C_HVFANSTAT              String    RO
+#    HVClkConf        C_HVCLKCONF              String    RW
+#    IPAddr           C_IPADDR                 String    RW
+#    IPNetMsk         C_IPNETMSK               String    RW
+#    IPGw             C_IPGW                   String    RW
+#    PWCurrent        C_PWCURRENT              String    RO
+#    SymbolicName     C_SYMBOLICNAME           String    RW
+#    CPULoad          C_CPULOAD                String    RO
+#    MemoryStatus     C_MEMORYSTATUS           String    RO
+#    PWFanStat        C_PWFANSTAT              String    RO
+#    PWVoltage        C_PWVOLTAGE              String    RO
+#    DHCPDStatus      C_DHCPDSTATUS            String    RO
+
+file longin.template {
+    pattern { R,                  PARAM,             DESC,                    SCAN    }
+            { "FrontPanIn",       "C_FRONTPANIN",    "System input status",   $(SCAN) }
+            { "FrontPanOut",      "C_FRONTPANOUT",   "System output status",  $(SCAN) }
+}
+
+file stringout.template {
+    pattern { R,                  PARAM,             DESC,                    NELM,   SCAN      }
+            { "SymbolicName",     "C_SYMBOLICNAME",  "Symbolic name",         "100",  $(SCAN)   }
+}
+
+file stringin.template {
+    pattern { R,                  PARAM,             DESC,                    NELM,   SCAN      }
+            { "SymbolicName-RB",  "C_SYMBOLICNAME",  "Symbolic name",         "100",  $(SCAN)   }
+            { "ModelName",        "C_MODELNAME",     "Model name",            "100",  "Passive" }
+            { "SwRelease",        "C_SWRELEASE",     "Software version",      "100",  "Passive" }
+}

--- a/CAENHVAsynApp/Db/ai.template
+++ b/CAENHVAsynApp/Db/ai.template
@@ -1,6 +1,6 @@
 record(ai,      "$(P)$(R)") {
-    field(PINI, "YES")
-    field(PREC, "2")
+    field(PINI, "$(PINI=YES)")
+    field(PREC, "$(PREC=2)")
     field(DESC, "$(DESC)")
     field(DTYP, "asynFloat64")
     field(SCAN, "$(SCAN)")

--- a/CAENHVAsynApp/Db/ao.template
+++ b/CAENHVAsynApp/Db/ao.template
@@ -1,9 +1,9 @@
 record(ao,      "$(P)$(R)") {
-    field(PINI, "YES")
-    field(PREC, "2")
+    field(PINI, "$(PINI=NO)")
+    field(PREC, "$(PREC=2)")
     field(DESC, "$(DESC)")
     field(DTYP, "asynFloat64")
-    field(SCAN, "Passive")
+    field(SCAN, "$(SCAN=Passive)")
     field(EGU,  "$(EGU)")
     field(LOPR, "$(LOPR)")
     field(HOPR, "$(HOPR)")

--- a/CAENHVAsynApp/Db/bi.template
+++ b/CAENHVAsynApp/Db/bi.template
@@ -1,7 +1,7 @@
 record(bi,      "$(P)$(R)") {
     field(DTYP, "asynUInt32Digital")
     field(DESC, "$(DESC)")
-    field(PINI, "YES")
+    field(PINI, "$(PINI=YES)")
     field(SCAN, "$(SCAN)")
     field(INP,  "@asynMask($(PORT),0,$(MASK))$(PARAM)")
     field(ZNAM, "$(ZNAM)")

--- a/CAENHVAsynApp/Db/bo.template
+++ b/CAENHVAsynApp/Db/bo.template
@@ -1,8 +1,8 @@
 record(bo,      "$(P)$(R)") {
     field(DTYP, "asynUInt32Digital")
     field(DESC, "$(DESC)")
-    field(PINI, "YES")
-    field(SCAN, "Passive")
+    field(PINI, "$(PINI=NO)")
+    field(SCAN, "$(SCAN=Passive)")
     field(OUT,  "@asynMask($(PORT),0,$(MASK))$(PARAM)")
     field(ZNAM, "$(ZNAM)")
     field(ONAM, "$(ONAM)")

--- a/CAENHVAsynApp/Db/longin.template
+++ b/CAENHVAsynApp/Db/longin.template
@@ -1,7 +1,7 @@
 record(longin,  "$(P)$(R)") {
     field(DTYP, "asynInt32")
     field(DESC, "$(DESC)")
-    field(PINI, "YES")
+    field(PINI, "$(PINI=YES)")
     field(SCAN, "$(SCAN)")
     field(INP,  "@asyn($(PORT))$(PARAM)")
     info(autosaveFields, "VAL")

--- a/CAENHVAsynApp/Db/longout.template
+++ b/CAENHVAsynApp/Db/longout.template
@@ -1,8 +1,8 @@
 record(longout, "$(P)$(R)") {
     field(DTYP, "asynInt32")
     field(DESC, "$(DESC)")
-    field(PINI, "YES")
-    field(SCAN, "Passive")
+    field(PINI, "$(PINI=NO)")
+    field(SCAN, "$(SCAN=Passive)")
     field(OUT,  "@asyn($(PORT))$(PARAM)")
     info(autosaveFields, "VAL")
 }

--- a/CAENHVAsynApp/Db/stringin.template
+++ b/CAENHVAsynApp/Db/stringin.template
@@ -1,9 +1,9 @@
 record(waveform, "$(P)$(R)") {
     field(DTYP,  "asynOctetRead")
     field(DESC,  "$(DESC)")
-    field(PINI,  "YES")
+    field(PINI,  "$(PINI=YES)")
     field(SCAN,  "$(SCAN)")
     field(NELM,  "$(NELM)")
-    field(FTVL,  "CHAR")
+    field(FTVL,  "$(FTVL=CHAR)")
     field(INP,   "@asyn($(PORT))$(PARAM)")
 }

--- a/CAENHVAsynApp/Db/stringout.template
+++ b/CAENHVAsynApp/Db/stringout.template
@@ -1,9 +1,9 @@
 record(waveform, "$(P)$(R)") {
     field(DTYP,  "asynOctetWrite")
     field(DESC,  "$(DESC)")
-    field(PINI,  "NO")
-    field(SCAN,  "Passive")
+    field(PINI,  "$(PINI=NO)")
+    field(SCAN,  "$(SCAN=Passive)")
     field(NELM,  "$(NELM)")
-    field(FTVL,  "CHAR")
+    field(FTVL,  "$(FTVL=CHAR)")
     field(INP,   "@asyn($(PORT))$(PARAM)")
 }


### PR DESCRIPTION
So they can be changed by the user when loading the files. As far as I understand, fields which control - for instance - power up and down sequences, should not have PINI=YES.

Please let me know what you think, or if there is any rationale behind those values that I didn't know.

Also, we have some substitution files that are currently living in our conda recipe of this module. Things such as:
 A1589-board.substitutions:

> file bi.template {
>     pattern { R,               PARAM,                DESC,                             ZNAM,  ONAM,   MASK,  SCAN    }
>             { "Status-PF",     "S$(SLOT)_BDSTATUS",  "Power fail",                     "No",  "Yes",  "1",   $(SCAN) }
> (...)
> 

Do you think it would be interesting to move these files to here?

The ones we currently have are:
A1589-board.substitutions
A2519-board.substitutions
A2552-board.substitutions
A7030-board.substitutions
A7030DP-channel.substitutions
A1589-channel.substitutions
A2519-channel.substitutions
A2552-channel.substitutions
A7030-channel.substitutions
SYx527.substitutions

In my opinion it would be nice to have everything in the community.