### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @slac-epics/tid-id-cse


### PR DESCRIPTION
This is so we get requested review automatically. Not sure if we want the whole department to be under codeowners or not.